### PR TITLE
Add help and profile utilities for Jarvis

### DIFF
--- a/discord-handlers.js
+++ b/discord-handlers.js
@@ -1436,6 +1436,7 @@ class DiscordHandlers {
 
     async handleUtilityCommands(message) {
         const content = message.content.trim().toLowerCase();
+        const rawContent = message.content.trim();
 
         if (content === "!reset") {
             try {
@@ -1445,6 +1446,70 @@ class DiscordHandlers {
             } catch (error) {
                 console.error("Reset error:", error);
                 await message.reply("Unable to reset memories, sir. Technical issue.");
+            }
+            return true;
+        }
+
+        if (content === "!help") {
+            try {
+                await message.channel.sendTyping();
+                const response = await this.jarvis.handleUtilityCommand(
+                    "help",
+                    message.author.username,
+                    message.author.id
+                );
+                await message.reply(response);
+            } catch (error) {
+                console.error("Help command error:", error);
+                await message.reply("Unable to display help right now, sir.");
+            }
+            return true;
+        }
+
+        if (content.startsWith("!profile")) {
+            try {
+                await message.channel.sendTyping();
+                const response = await this.jarvis.handleUtilityCommand(
+                    rawContent.substring(1),
+                    message.author.username,
+                    message.author.id
+                );
+                await message.reply(response || "Profile command processed, sir.");
+            } catch (error) {
+                console.error("Profile command error:", error);
+                await message.reply("Unable to access profile systems, sir.");
+            }
+            return true;
+        }
+
+        if (content.startsWith("!history")) {
+            try {
+                await message.channel.sendTyping();
+                const response = await this.jarvis.handleUtilityCommand(
+                    rawContent.substring(1),
+                    message.author.username,
+                    message.author.id
+                );
+                await message.reply(response || "No history available yet, sir.");
+            } catch (error) {
+                console.error("History command error:", error);
+                await message.reply("Unable to retrieve history, sir.");
+            }
+            return true;
+        }
+
+        if (content.startsWith("!recap")) {
+            try {
+                await message.channel.sendTyping();
+                const response = await this.jarvis.handleUtilityCommand(
+                    rawContent.substring(1),
+                    message.author.username,
+                    message.author.id
+                );
+                await message.reply(response || "Nothing to report just yet, sir.");
+            } catch (error) {
+                console.error("Recap command error:", error);
+                await message.reply("Unable to compile a recap, sir.");
             }
             return true;
         }
@@ -1876,8 +1941,11 @@ class DiscordHandlers {
             return await this.handleSlashCommandClip(interaction);
         }
 
+        const ephemeralCommands = new Set(["help", "profile", "history", "recap"]);
+        const shouldBeEphemeral = ephemeralCommands.has(interaction.commandName);
+
         try {
-            await interaction.deferReply({ ephemeral: false });
+            await interaction.deferReply({ ephemeral: shouldBeEphemeral });
         } catch (error) {
             if (error.code === 10062) {
                 console.warn("Ignored unknown interaction during deferReply.");
@@ -1936,6 +2004,38 @@ class DiscordHandlers {
             } else if (interaction.commandName === "reset") {
                 response = await this.jarvis.handleUtilityCommand(
                     "reset",
+                    interaction.user.username,
+                    interaction.user.id,
+                    true,
+                    interaction
+                );
+            } else if (interaction.commandName === "help") {
+                response = await this.jarvis.handleUtilityCommand(
+                    "help",
+                    interaction.user.username,
+                    interaction.user.id,
+                    true,
+                    interaction
+                );
+            } else if (interaction.commandName === "profile") {
+                response = await this.jarvis.handleUtilityCommand(
+                    "profile",
+                    interaction.user.username,
+                    interaction.user.id,
+                    true,
+                    interaction
+                );
+            } else if (interaction.commandName === "history") {
+                response = await this.jarvis.handleUtilityCommand(
+                    "history",
+                    interaction.user.username,
+                    interaction.user.id,
+                    true,
+                    interaction
+                );
+            } else if (interaction.commandName === "recap") {
+                response = await this.jarvis.handleUtilityCommand(
+                    "recap",
                     interaction.user.username,
                     interaction.user.id,
                     true,

--- a/index.js
+++ b/index.js
@@ -72,6 +72,56 @@ const commands = [
         .setDescription("Delete your conversation history and profile with Jarvis")
         .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()
+        .setName("help")
+        .setDescription("Show Jarvis command overview")
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName("profile")
+        .setDescription("View or update your Jarvis profile")
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("show")
+                .setDescription("Display your saved profile information"))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("set")
+                .setDescription("Update one of your profile preferences")
+                .addStringOption(option =>
+                    option
+                        .setName("key")
+                        .setDescription("Preference key to update")
+                        .setRequired(true))
+                .addStringOption(option =>
+                    option
+                        .setName("value")
+                        .setDescription("Value to store for the preference")
+                        .setRequired(true)))
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName("history")
+        .setDescription("Review your recent prompts")
+        .addIntegerOption(option =>
+            option
+                .setName("count")
+                .setDescription("How many prompts to show (max 20)")
+                .setRequired(false))
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName("recap")
+        .setDescription("Get a quick activity summary")
+        .addStringOption(option =>
+            option
+                .setName("window")
+                .setDescription("How far back to look")
+                .setRequired(false)
+                .addChoices(
+                    { name: "Last 6 hours", value: "6h" },
+                    { name: "Last 12 hours", value: "12h" },
+                    { name: "Last 24 hours", value: "24h" },
+                    { name: "Last 7 days", value: "7d" }
+                ))
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
         .setName("clip")
         .setDescription("Clip a message into an image")
         .addStringOption((option) =>


### PR DESCRIPTION
## Summary
- add slash commands for help, profile management, history, and recap along with updated registration
- implement profile preference updates, personal history views, and recap summaries in the utility handler
- extend database helpers for preference storage and time-windowed conversation lookups and expose new text command shortcuts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f4bc16baa4832fac508c0a0c29a7f5