### PR TITLE
Add online and offline user server stats channels

### DIFF
--- a/discord-handlers-parts/part-03.js
+++ b/discord-handlers-parts/part-03.js
@@ -161,6 +161,8 @@
                 const botChannel = await this.resolveGuildChannel(guild, config.botChannelId);
                 const channelCountChannel = await this.resolveGuildChannel(guild, config.channelCountChannelId);
                 const roleCountChannel = await this.resolveGuildChannel(guild, config.roleCountChannelId);
+                const onlineUsersChannel = await this.resolveGuildChannel(guild, config.onlineUsersChannelId);
+                const offlineUsersChannel = await this.resolveGuildChannel(guild, config.offlineUsersChannelId);
 
                 const lines = [
                     `Category: ${category ? `<#${category.id}>` : 'Missing'}`,
@@ -169,7 +171,9 @@
                     `Bot channel: ${botChannel ? `<#${botChannel.id}>` : 'Missing'}`,
                     `Channel count channel: ${channelCountChannel ? `<#${channelCountChannel.id}>` : 'Missing'}`,
                     `Role count channel: ${roleCountChannel ? `<#${roleCountChannel.id}>` : 'Missing'}`,
-                    `Current totals — Members: ${this.formatServerStatsValue(stats.total)}, Users: ${this.formatServerStatsValue(stats.userCount)}, Bots: ${this.formatServerStatsValue(stats.botCount)}, Channels: ${this.formatServerStatsValue(stats.channelCount)}, Roles: ${this.formatServerStatsValue(stats.roleCount)}`
+                    `Online users channel: ${onlineUsersChannel ? `<#${onlineUsersChannel.id}>` : 'Missing'}`,
+                    `Offline users channel: ${offlineUsersChannel ? `<#${offlineUsersChannel.id}>` : 'Missing'}`,
+                    `Current totals — Members: ${this.formatServerStatsValue(stats.total)}, Users: ${this.formatServerStatsValue(stats.userCount)}, Bots: ${this.formatServerStatsValue(stats.botCount)}, Channels: ${this.formatServerStatsValue(stats.channelCount)}, Roles: ${this.formatServerStatsValue(stats.roleCount)}, Online Users: ${this.formatServerStatsValue(stats.onlineUserCount)}, Offline Users: ${this.formatServerStatsValue(stats.offlineUserCount)}`
                 ];
 
                 await interaction.editReply(`Server statistics are active, sir.\n${lines.join('\n')}`);


### PR DESCRIPTION
## Summary
- add online and offline user channel labels to the server stats category and ensure the channels are provisioned
- calculate online and offline user counts alongside existing server stats and persist the new channel identifiers
- extend the server stats status response to surface the new channels and counts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa3b99c474832fbc0fd0c2852bbcc0