### PR TITLE
Fix command duplication and status formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -811,7 +811,7 @@ app.get("/", async (req, res) => {
             `Required: ${envRequiredCount}/${envRequiredTotal}`,
             missingRequired.length ? `Missing: ${missingRequired.join(', ')}` : 'Missing: None',
             `Optional: ${optionalConfigured}/${optionalTotal}`,
-            optionalEnabled.length ? `Enabled: ${optionalEnabled.join(', ')}` : 'Enabled: None'
+            optionalEnabled.length ? `Enabled: ${optionalEnabled.map(name => `- ${name}`).join('\n')}` : 'Enabled: None'
         ].join('\n');
 
         const dbLines = [


### PR DESCRIPTION
## Summary
- stop registering slash commands redundantly per guild to avoid duplicate entries
- clean up health dashboard output by using real line breaks and bullet the enabled optional env vars

## Testing
- manual Render deploy pending