### PR TITLE
Simplify status page env summary

### DIFF
--- a/index.js
+++ b/index.js
@@ -795,11 +795,8 @@ app.get("/", async (req, res) => {
             `Required: ${envRequiredCount}/${envRequiredTotal}`,
             missingRequired.length ? `Missing: ${missingRequired.join(', ')}` : 'Missing: None',
             `Optional: ${optionalConfigured}/${optionalTotal}`,
-            ...(
-                optionalEnabled.length
-                    ? ['Enabled:', ...optionalEnabled.map((name) => `- ${name}`)]
-                    : ['Enabled: None']
-            )
+            `Enabled: ${optionalEnabled.length}`,
+            ...optionalEnabled.map((name) => `- ${name}`)
         ].join('\\n');
 
         const dbLines = [


### PR DESCRIPTION
## Summary
- show the count of enabled optional env vars on the status page and list them without extra headings
- eliminates the stray block that previously created awkward spacing

## Testing
- pending Render redeploy