### PR TITLE
Add configurable legacy command prefix

### DIFF
--- a/config.js
+++ b/config.js
@@ -66,6 +66,11 @@ const rawConfig = {
         }
     },
 
+    // Legacy Command Configuration
+    legacy: {
+        defaultPrefix: process.env.JARVIS_LEGACY_PREFIX || '!'
+    },
+
     // Server Configuration
     server: {
         port: process.env.PORT || 3000,
@@ -114,7 +119,8 @@ const rawConfig = {
         digests: true,
         newsBriefings: true,
         macroReplies: true,
-        energyMeter: true
+        energyMeter: true,
+        config: true
     }
 };
 

--- a/database.js
+++ b/database.js
@@ -5,6 +5,8 @@
 const { MongoClient, ObjectId } = require('mongodb');
 const config = require('./config');
 
+const DEFAULT_PREFIX = config.legacy?.defaultPrefix || '!';
+
 class DatabaseManager {
     constructor() {
         this.client = null;
@@ -293,22 +295,37 @@ class DatabaseManager {
                 ownerId: ownerId || null,
                 moderatorRoleIds: [],
                 moderatorUserIds: [],
+                prefix: DEFAULT_PREFIX,
                 createdAt: now,
                 updatedAt: now
             };
             await collection.insertOne(guildConfig);
-        } else if (ownerId && guildConfig.ownerId !== ownerId) {
-            guildConfig.ownerId = ownerId;
-            guildConfig.updatedAt = new Date();
-            await collection.updateOne(
-                { guildId },
-                {
-                    $set: {
-                        ownerId: guildConfig.ownerId,
-                        updatedAt: guildConfig.updatedAt
+        } else {
+            let shouldUpdate = false;
+
+            if (!guildConfig.prefix || typeof guildConfig.prefix !== 'string') {
+                guildConfig.prefix = DEFAULT_PREFIX;
+                shouldUpdate = true;
+            }
+
+            if (ownerId && guildConfig.ownerId !== ownerId) {
+                guildConfig.ownerId = ownerId;
+                shouldUpdate = true;
+            }
+
+            if (shouldUpdate) {
+                guildConfig.updatedAt = new Date();
+                await collection.updateOne(
+                    { guildId },
+                    {
+                        $set: {
+                            ownerId: guildConfig.ownerId,
+                            prefix: guildConfig.prefix,
+                            updatedAt: guildConfig.updatedAt
+                        }
                     }
-                }
-            );
+                );
+            }
         }
 
         return guildConfig;
@@ -330,6 +347,7 @@ class DatabaseManager {
                 },
                 $setOnInsert: {
                     moderatorUserIds: [],
+                    prefix: DEFAULT_PREFIX,
                     createdAt: now
                 }
             },
@@ -337,6 +355,47 @@ class DatabaseManager {
         );
 
         return this.getGuildConfig(guildId, ownerId);
+    }
+
+    async setGuildPrefix(guildId, prefix) {
+        if (!this.isConnected) throw new Error('Database not connected');
+
+        const collection = this.db.collection(config.database.collections.guildConfigs);
+        const now = new Date();
+
+        const sanitized = typeof prefix === 'string' && prefix.trim() ? prefix.trim() : DEFAULT_PREFIX;
+
+        await collection.updateOne(
+            { guildId },
+            {
+                $set: {
+                    prefix: sanitized,
+                    updatedAt: now
+                },
+                $setOnInsert: {
+                    ownerId: null,
+                    moderatorRoleIds: [],
+                    moderatorUserIds: [],
+                    createdAt: now
+                }
+            },
+            { upsert: true }
+        );
+
+        return sanitized;
+    }
+
+    async getGuildPrefix(guildId) {
+        if (!this.isConnected || !guildId) {
+            return DEFAULT_PREFIX;
+        }
+
+        const guildConfig = await this.getGuildConfig(guildId);
+        if (guildConfig && typeof guildConfig.prefix === 'string' && guildConfig.prefix.trim()) {
+            return guildConfig.prefix.trim();
+        }
+
+        return DEFAULT_PREFIX;
     }
 
     async saveReactionRoleMessage(reactionRole) {

--- a/discord-handlers-parts/part-04.js
+++ b/discord-handlers-parts/part-04.js
@@ -939,7 +939,7 @@
             return await this.handleSlashCommandClip(interaction);
         }
 
-        const ephemeralCommands = new Set(["help", "profile", "history", "recap", "digest", "macro", "reactionrole", "automod", "serverstats", "memberlog", "ticket", "kb"]);
+        const ephemeralCommands = new Set(["help", "profile", "history", "recap", "digest", "macro", "reactionrole", "automod", "serverstats", "memberlog", "ticket", "kb", "config"]);
         const shouldBeEphemeral = ephemeralCommands.has(interaction.commandName);
 
         try {
@@ -1103,6 +1103,10 @@
                 return;
             } else if (interaction.commandName === "memberlog") {
                 await this.handleMemberLogCommand(interaction);
+                this.setCooldown(userId);
+                return;
+            } else if (interaction.commandName === "config") {
+                await this.handleConfigCommand(interaction);
                 this.setCooldown(userId);
                 return;
             } else if (interaction.commandName === "news") {

--- a/index.js
+++ b/index.js
@@ -658,6 +658,27 @@ const allCommands = [
                             { name: "Leave", value: "leave" }
                         )))
         .setContexts([InteractionContextType.Guild]),
+    new SlashCommandBuilder()
+        .setName("config")
+        .setDescription("Configure Jarvis server settings")
+        .addSubcommandGroup(group =>
+            group
+                .setName("prefix")
+                .setDescription("Manage the legacy command prefix")
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName("show")
+                        .setDescription("Display the current command prefix"))
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName("set")
+                        .setDescription("Update the command prefix for legacy commands")
+                        .addStringOption(option =>
+                            option
+                                .setName("value")
+                                .setDescription("Prefix to use (1-5 visible characters, no spaces)")
+                                .setRequired(true))))
+        .setContexts([InteractionContextType.Guild]),
 ];
 
 const commandFeatureMap = new Map([
@@ -684,7 +705,8 @@ const commandFeatureMap = new Map([
     ['reactionrole', 'reactionRoles'],
     ['automod', 'automod'],
     ['serverstats', 'serverStats'],
-    ['memberlog', 'memberLog']
+    ['memberlog', 'memberLog'],
+    ['config', 'config']
 ]);
 
 const featureFlags = config.features || {};


### PR DESCRIPTION
## Summary
- allow guild administrators to view and update the legacy message command prefix via /config prefix
- cache guild prefixes locally and persist them in MongoDB alongside other guild settings
- respect the configured prefix across admin/utility handlers while canonicalizing internally for legacy logic

## Testing
- manual sanity checks (requires Render redeploy)