### PR TITLE
Provision dedicated Lavalink worker on Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ data/
 .vscode/
 .idea/
 provider-state.json
+Lavalink.jar
+lavalink.jar:Zone.Identifier
+plugins/

--- a/Dockerfile.lavalink
+++ b/Dockerfile.lavalink
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+ARG LAVALINK_VERSION=4.1.1
+
+RUN apk add --no-cache curl && \
+    curl -L -o Lavalink.jar "https://github.com/lavalink-devs/Lavalink/releases/download/${LAVALINK_VERSION}/Lavalink.jar"
+
+COPY application.yml .
+
+EXPOSE 2333
+
+CMD ["java", "-jar", "Lavalink.jar"]

--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,15 @@
+server:
+  port: ${SERVER_PORT:2333}
+  address: 0.0.0.0
+
+lavalink:
+  server:
+    password: "${LAVALINK_SERVER_PASSWORD:render_pass_123}"
+    sources:
+      youtube: true
+      soundcloud: true
+      bandcamp: true
+      twitch: true
+      vimeo: true
+      http: true
+      local: false

--- a/render.yaml
+++ b/render.yaml
@@ -2,10 +2,14 @@ services:
   - type: web
     name: jarvis-discord-bot
     runtime: node
-    repo: https://github.com/HustleSynth/jarvis-ai # Replace with your repo
+    repo: https://github.com/not-antoni/jarvis-ai
     buildCommand: npm install
-    startCommand: node index.js
+    startCommand: npm start
     envVars:
+      - key: NODE_VERSION
+        value: 20
+      - key: JAVA_VERSION
+        value: 17
       - key: DISCORD_TOKEN
         sync: false
       - key: MONGO_PW
@@ -50,3 +54,22 @@ services:
         sync: false
       - key: PORT
         generateValue: true
+      - key: LAVALINK_HOST
+        fromService:
+          type: worker
+          name: jarvis-lavalink
+          property: host
+      - key: LAVALINK_PORT
+        value: 2333
+      - key: LAVALINK_PASSWORD
+        value: render_pass_123
+  - type: worker
+    name: jarvis-lavalink
+    runtime: docker
+    repo: https://github.com/not-antoni/jarvis-ai
+    dockerfilePath: Dockerfile.lavalink
+    envVars:
+      - key: JAVA_TOOL_OPTIONS
+        value: -Xmx256m
+      - key: SERVER_PORT
+        value: 2333

--- a/start-both.js
+++ b/start-both.js
@@ -1,0 +1,45 @@
+// Runs Lavalink (Java) and your Node bot side by side
+const { spawn } = require("child_process");
+
+const lavalinkHost = process.env.LAVALINK_HOST || "127.0.0.1";
+const isLocalLavalinkHost = ["127.0.0.1", "localhost", "::1"].includes(
+  lavalinkHost.trim().toLowerCase()
+);
+
+let lavalink = null;
+
+// ---- Start Lavalink ----
+if (isLocalLavalinkHost) {
+  lavalink = spawn("java", ["-jar", "Lavalink.jar"], {
+    stdio: "inherit"
+  });
+
+  lavalink.on("close", code =>
+    console.log(`Lavalink exited with code ${code}`)
+  );
+
+  lavalink.on("error", error =>
+    console.error("Failed to start Lavalink process:", error)
+  );
+} else {
+  console.log(
+    `Skipping embedded Lavalink launch; expecting external node at ${lavalinkHost}:${process.env.LAVALINK_PORT || 2333}`
+  );
+}
+
+// ---- Start Bot ----
+const bot = spawn("node", ["index.js"], {
+  stdio: "inherit"
+});
+bot.on("close", code =>
+  console.log(`Bot exited with code ${code}`)
+);
+
+// ---- Cleanup ----
+process.on("SIGINT", () => {
+  if (lavalink) {
+    lavalink.kill("SIGINT");
+  }
+  bot.kill("SIGINT");
+  process.exit();
+});


### PR DESCRIPTION
## Summary
- add a Docker-based Lavalink worker service for Render deployments
- wire Render env vars so the Discord bot connects to the worker node
- adjust start script to skip local Lavalink when using remote host

## Testing
- not run (deployment configuration change)