### PR TITLE
Align Lavalink host defaults with Render

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${SERVER_PORT:2333}
+  port: ${LAVALINK_PORT:${PORT:2333}}
   address: 0.0.0.0
 
 lavalink:

--- a/index.js
+++ b/index.js
@@ -28,12 +28,20 @@ const client = new Client({
     ]
 });
 
+const isRenderEnvironment = Boolean(process.env.RENDER_EXTERNAL_URL || process.env.RENDER_SERVICE_NAME);
+const resolvedLavalinkHost = process.env.LAVALINK_HOST || (isRenderEnvironment ? "jarvis-lavalink" : "127.0.0.1");
+const resolvedLavalinkPort = Number(process.env.LAVALINK_PORT || 2333);
+
 const lavalinkConfig = {
-    host: process.env.LAVALINK_HOST || "127.0.0.1",
-    port: Number(process.env.LAVALINK_PORT || 2333),
-    password: process.env.LAVALINK_PASSWORD || "render_pass_123",
+    host: resolvedLavalinkHost,
+    port: resolvedLavalinkPort,
+    password: process.env.LAVALINK_PASSWORD || process.env.LAVALINK_SERVER_PASSWORD || "render_pass_123",
     secure: process.env.LAVALINK_SECURE === "true"
 };
+
+console.log(
+    `Lavalink node target => host: ${lavalinkConfig.host}, port: ${lavalinkConfig.port}, secure: ${lavalinkConfig.secure}`
+);
 
 // --- Lavalink setup ---
 client.manager = new Manager({

--- a/start-both.js
+++ b/start-both.js
@@ -1,7 +1,10 @@
 // Runs Lavalink (Java) and your Node bot side by side
 const { spawn } = require("child_process");
 
-const lavalinkHost = process.env.LAVALINK_HOST || "127.0.0.1";
+const isRenderEnvironment = Boolean(process.env.RENDER_EXTERNAL_URL || process.env.RENDER_SERVICE_NAME);
+const lavalinkHost = process.env.LAVALINK_HOST || (isRenderEnvironment ? "jarvis-lavalink" : "127.0.0.1");
+process.env.LAVALINK_HOST = lavalinkHost;
+process.env.LAVALINK_PORT = process.env.LAVALINK_PORT || process.env.PORT || "2333";
 const isLocalLavalinkHost = ["127.0.0.1", "localhost", "::1"].includes(
   lavalinkHost.trim().toLowerCase()
 );


### PR DESCRIPTION
## Summary
- make Lavalink listen on LAVALINK_PORT or PORT when provided
- default Lavalink host to the Render worker hostname when running on Render
- ensure the start script propagates resolved host/port to the bot process

## Testing
- not run (requires Render deployment)