### PR TITLE
Use Render dynamic port for Lavalink

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const resolveLavalinkHost = () => {
 
 const lavalinkConfig = {
     host: resolveLavalinkHost(),
-    port: Number(process.env.LAVALINK_PORT || 2333),
+    port: Number(process.env.LAVALINK_PORT || process.env.PORT || 2333),
     password: process.env.LAVALINK_PASSWORD || "render_pass_123",
     secure: process.env.LAVALINK_SECURE === "true"
 };

--- a/start-both.js
+++ b/start-both.js
@@ -74,13 +74,16 @@ async function main() {
 
   const lavalinkHost = normalizeHost(process.env.LAVALINK_HOST);
   process.env.LAVALINK_HOST = lavalinkHost;
-  process.env.LAVALINK_PORT = process.env.LAVALINK_PORT || "2333";
+  const resolvedPort = String(process.env.LAVALINK_PORT || process.env.PORT || "2333");
+  process.env.LAVALINK_PORT = resolvedPort;
 
   const isLocalLavalinkHost = ["127.0.0.1", "localhost", "::1"].includes(
     lavalinkHost.trim().toLowerCase()
   );
 
   let lavalink = null;
+
+  console.log(`Configured Lavalink endpoint: ${lavalinkHost}:${resolvedPort}`);
 
   // ---- Start Lavalink ----
   if (isLocalLavalinkHost) {
@@ -97,7 +100,7 @@ async function main() {
     );
   } else {
     console.log(
-      `Skipping embedded Lavalink launch; expecting external node at ${lavalinkHost}:${process.env.LAVALINK_PORT || 2333}`
+      `Skipping embedded Lavalink launch; expecting external node at ${lavalinkHost}:${resolvedPort}`
     );
   }
 


### PR DESCRIPTION
## Summary
- resolve the Lavalink node port using LAVALINK_PORT, then fall back to Render's PORT
- propagate the resolved port to both the Lavalink config and the bot before launch
- add runtime logging so deployments can confirm the chosen host/port

## Testing
- not run (requires Render deployment)