### PR TITLE
feat: native music manager

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ const rawConfig = {
             'Guilds',
             'GuildMessages',
             'MessageContent',
+            'GuildVoiceStates',
             'GuildMembers',
             'DirectMessages',
             'GuildMessageReactions',


### PR DESCRIPTION
## Summary
- replace Lavalink with @discordjs/voice + play-dl queue manager
- wire music slash commands to use the shared manager
- remove Lavalink runtime artifacts and add new math engine updates

## Testing
- not run