### PR TITLE
fix: stabilize YouTube streaming pipeline

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -10,4 +10,4 @@
 - https://discordjs.guide/creating-your-bot/slash-commands
 
 ## Library Docs
-- https://github.com/fent/node-ytdl-core
+- https://github.com/distubejs/ytdl-core

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.0.0",
         "@discordjs/voice": "^0.16.1",
+        "@distube/ytdl-core": "^4.16.12",
         "@google/generative-ai": "^0.24.1",
         "canvas": "^3.2.0",
         "cohere-ai": "^7.19.0",
@@ -28,7 +29,6 @@
         "openai": "^5.20.1",
         "pdf-parse": "^1.1.2",
         "sharp": "^0.34.4",
-        "ytdl-core": "^4.11.5",
         "zod": "^3.25.76"
       }
     },
@@ -970,6 +970,57 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@distube/ytdl-core": {
+      "version": "4.16.12",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.12.tgz",
+      "integrity": "sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==",
+      "dependencies": {
+        "http-cookie-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^5.1.2",
+        "undici": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
+      }
+    },
+    "node_modules/@distube/ytdl-core/node_modules/http-cookie-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.2.tgz",
+      "integrity": "sha512-aHaES6SOFtnSlmWu0yEaaQvu+QexUG2gscSAvMhJ7auzW8r/jYOgGrzuAm9G9nHbksuhz7Lw4zOwDHmfQaxZvw==",
+      "dependencies": {
+        "agent-base": "^7.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@distube/ytdl-core/node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4474,6 +4525,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4481,6 +4548,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -4690,19 +4768,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.0.0",
     "@discordjs/voice": "^0.16.1",
+    "@distube/ytdl-core": "^4.16.12",
     "@google/generative-ai": "^0.24.1",
     "canvas": "^3.2.0",
     "cohere-ai": "^7.19.0",
@@ -39,7 +40,6 @@
     "openai": "^5.20.1",
     "pdf-parse": "^1.1.2",
     "sharp": "^0.34.4",
-    "ytdl-core": "^4.11.5",
     "zod": "^3.25.76"
   }
 }

--- a/src/core/musicManager.js
+++ b/src/core/musicManager.js
@@ -1,3 +1,5 @@
+process.env.YTDL_NO_UPDATE = process.env.YTDL_NO_UPDATE || '1';
+
 const {
     joinVoiceChannel,
     createAudioPlayer,
@@ -8,7 +10,25 @@ const {
     entersState,
     demuxProbe
 } = require('@discordjs/voice');
-const ytdl = require('ytdl-core');
+const ytdl = require('@distube/ytdl-core');
+
+const USER_AGENT =
+    process.env.YTDL_USER_AGENT ||
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36';
+const YTDL_BASE_OPTIONS = {
+    filter: 'audioonly',
+    quality: 'highestaudio',
+    dlChunkSize: 0,
+    highWaterMark: 1 << 25,
+    liveBuffer: 1 << 17,
+    requestOptions: {
+        headers: {
+            'User-Agent': USER_AGENT,
+            'Accept-Language': 'en-US,en;q=0.9',
+            Referer: 'https://www.youtube.com/'
+        }
+    }
+};
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -73,25 +93,7 @@ class MusicManager {
         }
 
         try {
-            const ytdlStream = ytdl(video.url, {
-                filter: 'audioonly',
-                quality: 'highestaudio',
-                dlChunkSize: 0,
-                highWaterMark: 1 << 25,
-                liveBuffer: 1 << 17
-            });
-
-            ytdlStream.once('error', (streamError) => {
-                console.error('YouTube stream error:', streamError);
-                try {
-                    ytdlStream.destroy(streamError);
-                } catch (destroyError) {
-                    console.error('Failed to destroy YouTube stream:', destroyError);
-                }
-                state.player.stop();
-            });
-
-            const { stream, type } = await demuxProbe(ytdlStream);
+            const { stream, type } = await this.createYouTubeStream(video.url);
             const resource = createAudioResource(stream, { inputType: type });
 
             state.player.play(resource);
@@ -108,7 +110,8 @@ class MusicManager {
             }
         } catch (error) {
             console.error('Music playback error:', error);
-            const failureMessage = typeof error?.message === 'string' && error.message.includes('429')
+            const isRateLimited = this.isRecoverableYouTubeError(error);
+            const failureMessage = isRateLimited
                 ? '⚠️ YouTube is throttling requests right now. Please try again in a moment, sir.'
                 : `⚠️ Could not play **${video.title}**.`;
 
@@ -189,6 +192,109 @@ class MusicManager {
         }
 
         return lines.length ? lines.join('\n') : 'Queue is empty.';
+    }
+
+    getYTDLOptions(overrides = {}) {
+        const mergedRequestOptions = {
+            ...YTDL_BASE_OPTIONS.requestOptions,
+            ...(overrides.requestOptions || {})
+        };
+
+        return {
+            ...YTDL_BASE_OPTIONS,
+            ...overrides,
+            requestOptions: mergedRequestOptions
+        };
+    }
+
+    async createYouTubeStream(videoUrl) {
+        const baseOptions = this.getYTDLOptions();
+
+        try {
+            return await this.probeStream(() => ytdl(videoUrl, baseOptions));
+        } catch (error) {
+            if (!this.isRecoverableYouTubeError(error)) {
+                throw error;
+            }
+
+            try {
+                const info = await ytdl.getInfo(videoUrl, {
+                    requestOptions: baseOptions.requestOptions,
+                    lang: 'en'
+                });
+
+                const audioFormat = ytdl.chooseFormat(info.formats, {
+                    quality: baseOptions.quality,
+                    filter: baseOptions.filter
+                });
+
+                if (!audioFormat || !audioFormat.url) {
+                    throw error;
+                }
+
+                return await this.probeStream(() =>
+                    ytdl.downloadFromInfo(info, this.getYTDLOptions({ format: audioFormat }))
+                );
+            } catch (secondaryError) {
+                secondaryError.previous = error;
+                throw secondaryError;
+            }
+        }
+    }
+
+    async probeStream(factory) {
+        return new Promise((resolve, reject) => {
+            let sourceStream;
+
+            const finalize = () => {
+                if (sourceStream) {
+                    sourceStream.removeListener('error', handleError);
+                }
+            };
+
+            const handleError = (error) => {
+                finalize();
+                if (sourceStream && typeof sourceStream.destroy === 'function') {
+                    try {
+                        sourceStream.destroy(error);
+                    } catch (destroyError) {
+                        console.error('Failed to destroy YouTube stream:', destroyError);
+                    }
+                }
+                reject(error);
+            };
+
+            try {
+                sourceStream = factory();
+            } catch (factoryError) {
+                reject(factoryError);
+                return;
+            }
+
+            sourceStream.once('error', handleError);
+
+            demuxProbe(sourceStream)
+                .then(({ stream, type }) => {
+                    finalize();
+                    resolve({ stream, type });
+                })
+                .catch(handleError);
+        });
+    }
+
+    isRecoverableYouTubeError(error) {
+        if (!error) {
+            return false;
+        }
+
+        if (typeof error.statusCode === 'number' && [403, 410, 429].includes(error.statusCode)) {
+            return true;
+        }
+
+        const message = String(error.message || '').toLowerCase();
+        return ['410', '403', '429', 'throttle', 'signature', 'error checking for updates'].some((token) =>
+            message.includes(token)
+        );
     }
 
     async createConnection(guildId, voiceChannel) {


### PR DESCRIPTION
## Summary
- replace the brittle play-dl/ytdl-core combo with the maintained @distube/ytdl-core fork
- demux audio with @discordjs/voice.demuxProbe and retry via getInfo when the primary stream returns 403/410
- silence ytdl update checks via YTDL_NO_UPDATE and document the new dependency

## Testing
- not run