### PR TITLE
fix: stabilize YouTube streaming pipeline

### DIFF
--- a/src/core/musicManager.js
+++ b/src/core/musicManager.js
@@ -1,4 +1,7 @@
 process.env.YTDL_NO_UPDATE = process.env.YTDL_NO_UPDATE || '1';
+if (typeof global.File === 'undefined') {
+    global.File = class File {};
+}
 
 const {
     joinVoiceChannel,


### PR DESCRIPTION
## Summary\n- swap in @distube/ytdl-core with spoofed UA and disabled update checks to avoid rate limit crashes\n- wrap stream creation in demux probing + getInfo fallback so 403/410 responses retry gracefully\n- polyfill the File global under Node 18 so the bundled undici dependency loads\n\n## Testing\n- not run