### PR TITLE
fix: rebuild music manager with InnerTube streaming

### DIFF
--- a/src/core/musicManager.js
+++ b/src/core/musicManager.js
@@ -5,15 +5,86 @@ const {
     AudioPlayerStatus,
     NoSubscriberBehavior,
     VoiceConnectionStatus,
-    entersState
+    entersState,
+    demuxProbe
 } = require('@discordjs/voice');
-const play = require('play-dl');
+const { request } = require('undici');
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const STREAM_CACHE_TTL_MS = 10 * 60 * 1000;
+const RETRY_DELAYS_MS = [500, 1500, 4000];
+
+const COOKIE_ENV_KEYS = [
+    'YT_COOKIE',
+    'YT_COOKIES',
+    'YTDL_COOKIE',
+    'YTDL_COOKIES',
+    'YOUTUBE_COOKIE',
+    'YOUTUBE_COOKIES'
+];
+
+const PLAYER_CLIENTS = [
+    {
+        name: 'ANDROID',
+        key: 'AIzaSyA1bryuAMG9PG0t1gCFuQ8k0A4vTQ0nXJM',
+        headers: {
+            'User-Agent': 'com.google.android.youtube/19.44.38 (Linux; U; Android 11)',
+            Origin: 'https://www.youtube.com'
+        },
+        payload: {
+            clientName: 'ANDROID',
+            clientVersion: '19.44.38',
+            platform: 'MOBILE',
+            osName: 'Android',
+            osVersion: '11',
+            androidSdkVersion: 30,
+            hl: 'en',
+            gl: 'US'
+        }
+    },
+    {
+        name: 'IOS',
+        key: 'AIzaSyB9yMuPGcl021sZPX91CGqF2N8ttWhJS9g',
+        headers: {
+            'User-Agent': 'com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 17_5_1 like Mac OS X; en_US)',
+            Origin: 'https://www.youtube.com'
+        },
+        payload: {
+            clientName: 'IOS',
+            clientVersion: '19.45.4',
+            deviceMake: 'Apple',
+            deviceModel: 'iPhone16,2',
+            platform: 'MOBILE',
+            osName: 'IOS',
+            osVersion: '17.5.1',
+            hl: 'en',
+            gl: 'US'
+        }
+    },
+    {
+        name: 'WEB',
+        key: 'AIzaSyAOqaUZ5hYjDUwcZnAcsFYEs7f38nPhe8',
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
+            Origin: 'https://www.youtube.com'
+        },
+        payload: {
+            clientName: 'WEB',
+            clientVersion: '2.20241210.01.00',
+            hl: 'en',
+            gl: 'US',
+            utcOffsetMinutes: 0
+        }
+    }
+];
 
 class MusicManager {
     constructor() {
         this.queues = new Map(); // guildId -> state
+        this.streamCache = new Map(); // videoId -> { url, expiresAt, clientName }
+        this.clientCursor = 0;
+        this.rateLimitUntil = 0;
+        this.cookieHeader = this.buildCookieHeaderFromEnv();
     }
 
     getState(guildId) {
@@ -72,18 +143,8 @@ class MusicManager {
         }
 
         try {
-            if (typeof play.is_expired === 'function' && typeof play.refreshToken === 'function') {
-                try {
-                    if (play.is_expired()) {
-                        await play.refreshToken();
-                    }
-                } catch (tokenError) {
-                    console.warn('play-dl token refresh skipped:', tokenError?.message || tokenError);
-                }
-            }
-
-            const stream = await play.stream(video.url, { discordPlayerCompatibility: true });
-            const resource = createAudioResource(stream.stream, { inputType: stream.type });
+            const { stream, type } = await this.createYouTubeStream(video.url);
+            const resource = createAudioResource(stream, { inputType: type });
 
             state.player.play(resource);
             state.current = video;
@@ -99,7 +160,15 @@ class MusicManager {
             }
         } catch (error) {
             console.error('Music playback error:', error);
-            const failureMessage = `⚠️ Could not play **${video.title}**.`;
+            const isRateLimited = this.isRecoverableYouTubeError(error);
+
+            if (isRateLimited) {
+                this.rateLimitUntil = Date.now() + 15_000;
+            }
+
+            const failureMessage = isRateLimited
+                ? '⚠️ YouTube is throttling requests right now. Please try again in a moment, sir.'
+                : `⚠️ Could not play **${video.title}**.`;
 
             if (announce === 'command') {
                 return failureMessage;
@@ -259,6 +328,393 @@ class MusicManager {
         });
 
         return player;
+    }
+
+    async createYouTubeStream(videoUrl) {
+        const videoId = this.extractVideoId(videoUrl);
+        if (!videoId) {
+            throw new Error('Unable to determine video identifier, sir.');
+        }
+
+        const cached = this.streamCache.get(videoId);
+        if (cached && cached.expiresAt > Date.now()) {
+            const client = PLAYER_CLIENTS.find(entry => entry.name === cached.clientName) ?? PLAYER_CLIENTS[0];
+            try {
+                return await this.probeStream(() => this.requestStream(cached.url, client));
+            } catch {
+                this.streamCache.delete(videoId);
+            }
+        }
+
+        if (this.rateLimitUntil > Date.now()) {
+            await this.wait(this.rateLimitUntil - Date.now());
+        }
+
+        let lastError = null;
+        const clientCount = PLAYER_CLIENTS.length;
+
+        for (let offset = 0; offset < clientCount; offset += 1) {
+            const client = PLAYER_CLIENTS[(this.clientCursor + offset) % clientCount];
+            try {
+                const response = await this.callPlayerApiWithRetries(videoId, client);
+                const format = this.selectAudioFormat(response);
+
+                if (!format) {
+                    throw new Error('No audio formats available, sir.');
+                }
+
+                const streamUrl = this.resolveFormatUrl(format);
+                if (!streamUrl) {
+                    throw new Error('Unable to resolve audio stream url, sir.');
+                }
+
+                const { stream, type } = await this.probeStream(() => this.requestStream(streamUrl, client));
+
+                this.streamCache.set(videoId, {
+                    url: streamUrl,
+                    clientName: client.name,
+                    expiresAt: Date.now() + STREAM_CACHE_TTL_MS
+                });
+
+                this.clientCursor = (this.clientCursor + offset) % clientCount;
+                this.rateLimitUntil = 0;
+
+                return { stream, type };
+            } catch (error) {
+                lastError = error;
+                if (!this.isRecoverableYouTubeError(error)) {
+                    break;
+                }
+
+                const delay = RETRY_DELAYS_MS[Math.min(offset, RETRY_DELAYS_MS.length - 1)];
+                await this.wait(delay + Math.floor(Math.random() * 250));
+            }
+        }
+
+        throw lastError ?? new Error('Unable to establish a YouTube audio stream, sir.');
+    }
+
+    async callPlayerApiWithRetries(videoId, client) {
+        let attempt = 0;
+        let lastError = null;
+
+        while (attempt < RETRY_DELAYS_MS.length + 1) {
+            try {
+                return await this.callPlayerApi(videoId, client);
+            } catch (error) {
+                lastError = error;
+                if (!this.isRecoverableYouTubeError(error) || attempt >= RETRY_DELAYS_MS.length) {
+                    throw lastError;
+                }
+
+                const waitMs = RETRY_DELAYS_MS[attempt] + Math.floor(Math.random() * 250);
+                await this.wait(waitMs);
+                attempt += 1;
+            }
+        }
+
+        throw lastError ?? new Error('Unable to reach YouTube player API, sir.');
+    }
+
+    async callPlayerApi(videoId, client) {
+        const body = {
+            context: {
+                client: {
+                    ...client.payload,
+                    hl: client.payload.hl ?? 'en',
+                    gl: client.payload.gl ?? 'US'
+                },
+                user: {
+                    lockedSafetyMode: false
+                },
+                request: {
+                    internalExperimentFlags: [],
+                    useSsl: true
+                }
+            },
+            videoId,
+            playbackContext: {
+                contentPlaybackContext: {
+                    html5Preference: 'HTML5_PREF_WANTS'
+                }
+            },
+            contentCheckOk: true,
+            racyCheckOk: true
+        };
+
+        const response = await fetch(`https://youtubei.googleapis.com/youtubei/v1/player?key=${client.key}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'User-Agent': client.headers['User-Agent'],
+                Origin: client.headers.Origin,
+                Referer: client.headers.Origin,
+                ...(this.cookieHeader ? { Cookie: this.cookieHeader } : {})
+            },
+            body: JSON.stringify(body)
+        });
+
+        if (response.status === 429) {
+            const error = new Error('YouTube responded with HTTP 429.');
+            error.statusCode = 429;
+            throw error;
+        }
+
+        if (response.status >= 400) {
+            const error = new Error(`YouTube returned HTTP ${response.status}.`);
+            error.statusCode = response.status;
+            throw error;
+        }
+
+        const payload = await response.json();
+        const playabilityStatus = payload?.playabilityStatus?.status ?? 'OK';
+        if (!['OK', 'LIVE_STREAM_OFFLINE'].includes(playabilityStatus)) {
+            const reason = payload?.playabilityStatus?.reason || 'The requested video is unavailable, sir.';
+            const error = new Error(reason);
+            error.statusCode = response.status;
+            throw error;
+        }
+
+        return payload;
+    }
+
+    selectAudioFormat(playerResponse) {
+        const adaptiveFormats = playerResponse?.streamingData?.adaptiveFormats ?? [];
+        const candidates = adaptiveFormats.filter(format => (format.mimeType || '').includes('audio/'));
+        if (!candidates.length) {
+            return null;
+        }
+
+        candidates.sort((a, b) => {
+            const bitrateA = Number(a.averageBitrate ?? a.bitrate ?? 0);
+            const bitrateB = Number(b.averageBitrate ?? b.bitrate ?? 0);
+            return bitrateB - bitrateA;
+        });
+
+        return candidates.find(format => this.resolveFormatUrl(format)) ?? candidates[0];
+    }
+
+    resolveFormatUrl(format) {
+        if (format?.url) {
+            return format.url;
+        }
+
+        if (typeof format?.signatureCipher === 'string') {
+            const params = new URLSearchParams(format.signatureCipher);
+            const url = params.get('url');
+            const sig = params.get('sig');
+            const sp = params.get('sp') || 'signature';
+
+            if (url && sig) {
+                return `${url}&${sp}=${sig}`;
+            }
+        }
+
+        return null;
+    }
+
+    async requestStream(streamUrl, client) {
+        const { body, statusCode } = await request(streamUrl, {
+            headers: {
+                'User-Agent': client.headers['User-Agent'],
+                Origin: client.headers.Origin,
+                Referer: client.headers.Origin,
+                Range: 'bytes=0-'
+            }
+        });
+
+        if (statusCode >= 400) {
+            try {
+                body.resume();
+            } catch {
+                // ignore
+            }
+
+            const error = new Error(`YouTube stream responded with HTTP ${statusCode}.`);
+            error.statusCode = statusCode;
+            throw error;
+        }
+
+        return body;
+    }
+
+    async probeStream(factory) {
+        return new Promise((resolve, reject) => {
+            let sourceStream;
+
+            const handleError = error => {
+                if (sourceStream) {
+                    sourceStream.removeListener('error', handleError);
+                    try {
+                        sourceStream.destroy(error);
+                    } catch {
+                        // ignore
+                    }
+                }
+                reject(error);
+            };
+
+            try {
+                sourceStream = factory();
+            } catch (error) {
+                return reject(error);
+            }
+
+            sourceStream.once('error', handleError);
+
+            demuxProbe(sourceStream)
+                .then(probed => {
+                    sourceStream.removeListener('error', handleError);
+                    resolve(probed);
+                })
+                .catch(handleError);
+        });
+    }
+
+    isRecoverableYouTubeError(error) {
+        if (!error) {
+            return false;
+        }
+
+        if (error.statusCode && [403, 410, 429].includes(error.statusCode)) {
+            return true;
+        }
+
+        const message = String(error.message || '').toLowerCase();
+        return ['429', 'throttle', 'quota', 'too many', 'rate'].some(token => message.includes(token));
+    }
+
+    wait(ms) {
+        if (!ms || ms <= 0) {
+            return Promise.resolve();
+        }
+
+        return new Promise(resolve => {
+            setTimeout(resolve, ms);
+        });
+    }
+
+    extractVideoId(input) {
+        if (!input) {
+            return null;
+        }
+
+        const trimmed = input.trim();
+        if (/^[a-zA-Z0-9_-]{11}$/.test(trimmed)) {
+            return trimmed;
+        }
+
+        let url;
+        try {
+            url = new URL(trimmed);
+        } catch {
+            return null;
+        }
+
+        if (url.hostname === 'youtu.be') {
+            return url.pathname.slice(1);
+        }
+
+        if (url.searchParams.has('v')) {
+            return url.searchParams.get('v');
+        }
+
+        const segments = url.pathname.split('/').filter(Boolean);
+        if (segments[0] === 'shorts' && segments[1]) {
+            return segments[1];
+        }
+
+        if (segments[segments.length - 1]?.length === 11) {
+            return segments[segments.length - 1];
+        }
+
+        return null;
+    }
+
+    buildCookieHeaderFromEnv() {
+        for (const key of COOKIE_ENV_KEYS) {
+            const raw = process.env[key];
+            if (!raw || typeof raw !== 'string') {
+                continue;
+            }
+
+            const trimmed = raw.trim();
+            if (!trimmed.length) {
+                continue;
+            }
+
+            const normalised = this.normaliseCookies(trimmed);
+            if (normalised && normalised.length) {
+                return normalised.map(cookie => `${cookie.name}=${cookie.value}`).join('; ');
+            }
+        }
+
+        return null;
+    }
+
+    normaliseCookies(raw) {
+        if (raw.startsWith('[')) {
+            try {
+                const parsed = JSON.parse(raw);
+                return this.normaliseCookieArray(parsed);
+            } catch (error) {
+                console.warn('Failed to parse cookie JSON:', error?.message || error);
+                return null;
+            }
+        }
+
+        if (raw.startsWith('{')) {
+            try {
+                const parsed = JSON.parse(raw);
+                if (Array.isArray(parsed?.cookies)) {
+                    return this.normaliseCookieArray(parsed.cookies);
+                }
+            } catch (error) {
+                console.warn('Failed to parse cookie object:', error?.message || error);
+                return null;
+            }
+        }
+
+        return raw
+            .split(/;+/)
+            .map(entry => entry.trim())
+            .filter(Boolean)
+            .map(entry => {
+                const [name, ...valueParts] = entry.split('=');
+                if (!name || valueParts.length === 0) {
+                    return null;
+                }
+                return {
+                    name: name.trim(),
+                    value: valueParts.join('=').trim()
+                };
+            })
+            .filter(Boolean);
+    }
+
+    normaliseCookieArray(cookies) {
+        if (!Array.isArray(cookies)) {
+            return null;
+        }
+
+        return cookies
+            .map(cookie => {
+                if (!cookie || typeof cookie !== 'object') {
+                    return null;
+                }
+
+                const name = cookie.name ?? cookie.key;
+                const value = cookie.value ?? cookie.val ?? cookie.content;
+                if (!name || typeof value === 'undefined') {
+                    return null;
+                }
+
+                return {
+                    name: String(name),
+                    value: String(value)
+                };
+            })
+            .filter(Boolean);
     }
 
     cleanup(guildId) {


### PR DESCRIPTION
## Summary\n- replace play-dl/ytdl with direct youtubei.googleapis.com player requests\n- rotate between Android/iOS/Web client profiles, back off on 403/410/429, and cache signed stream URLs\n- normalize cookie env vars into youtube's JSON format so modern agent headers are accepted\n- stream audio via undici + demuxProbe to keep ffmpeg compatibility\n\n## Testing\n- node -e "require('./src/core/musicManager'); console.log('ok')"