### PR TITLE
fix: add yt-dlp cookie shim

### DIFF
--- a/src/core/musicManager.js
+++ b/src/core/musicManager.js
@@ -18,6 +18,11 @@ class MusicManager {
         this.queues = new Map(); // guildId -> state
     }
 
+    // Legacy helper retained for compatibility with older runtime references.
+    buildCookieHeaderFromEnv() {
+        return null;
+    }
+
     getState(guildId) {
         return this.queues.get(guildId) ?? null;
     }


### PR DESCRIPTION
## Summary\n- keep the yt-dlp playback pipeline but add a legacy buildCookieHeaderFromEnv stub\n- prevents older runtime bootstraps from crashing when they call the former helper\n\n## Testing\n- node -e "require('./src/core/musicManager'); console.log('ok')"