### PR TITLE
fix: fall back to ffmpeg-static before remote builds

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -15,6 +15,7 @@
 - The bot boots a local ffmpeg binary automatically from the latest BtbN auto-builds; no manual install required.
 - Deploy with Node.js 22.12+ (set `NODE_VERSION=22.12.0`) and disable optional deps (`NPM_CONFIG_OPTIONAL=false`) so voice binaries install without compilation.
 - @discordjs/voice 0.19 also needs `@snazzah/davey`; this is auto-installed but ensure deployments include it.
+- `ffmpeg-static` is bundled and used first; remote downloads are attempted only as a fallback when a platform-specific build is missing.
 
 ## Guild Whitelist
 - Music commands are limited to guild IDs in `MUSIC_GUILD_WHITELIST` (defaults include `1403664986089324606` and `858444090374881301`).


### PR DESCRIPTION
## Summary\n- try  first so deployments don’t hit GitHub API limits\n- when the API is unavailable, fall back to the latest direct download URL\n- doc notes updated to clarify the ffmpeg bootstrap order\n\n## Testing\n- npm install\n- node -e "require('./src/core/musicManager'); console.log('ok')"