### PR TITLE
Improve music playback resiliency

### DIFF
--- a/src/utils/ytDlp.js
+++ b/src/utils/ytDlp.js
@@ -381,14 +381,15 @@ async function createDownloadTask(videoId, videoUrl) {
         args.splice(args.length - 1, 0, '--cookies', cookieFile);
     }
 
+    let cancelled = false;
+    const envVars = { ...process.env, YTDLP_NO_CHECK: '1', YTDL_NO_UPDATE: '1' };
     if (ffprobePath) {
-        args.splice(args.length - 1, 0, '--ffprobe-location', ffprobePath);
+        envVars.FFPROBE = ffprobePath;
     }
 
-    let cancelled = false;
     const child = spawn(binaryPath, args, {
         stdio: ['ignore', 'inherit', 'inherit'],
-        env: { ...process.env, YTDLP_NO_CHECK: '1', YTDL_NO_UPDATE: '1' }
+        env: envVars
     });
 
     const promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- replace Lavalink/play-dl stack with yt-dlp + ffmpeg bootstrap and hardened queue manager
- auto-update yt-dlp safely, respect cookies env parsing, and expose URL-aware /play helper
- bundle davey/opusscript voice deps and add env-to-file cookie minifier for admins
- set FFPROBE env instead of unsupported --ffprobe-location flag to avoid yt-dlp CLI errors

## Testing
- python3 scripts/minify_cookies.py /tmp/cookies.json
- export YTDLP_COOKIES_JSON='[\n {"name": "SID", "value": "abc"}\n]\n' && python3 scripts/minify_cookies.py
- export YTDLP_COOKIES_JSON='[\n {"name": "SID", "value": "abc"}\n]\n' && python3 scripts/minify_cookies.py
