### PR TITLE
Reduce yt-dlp update churn

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -18,6 +18,7 @@
 - You can tweak extractor behaviour with `YTDLP_EXTRACTOR_ARGS`; the default prefers Android/embedded clients to avoid `nsig` warnings.
 - The bundled binary auto-updates every 12 hours; override with `YTDLP_UPDATE_INTERVAL_MS` or disable the built-in GitHub check noise via `YTDL_NO_UPDATE=1`.
 - Use `scripts/minify_cookies.py` to compact either the `YTDLP_COOKIES_JSON` env value or a browser export into a single-line string for deployment.
+- Set `YTDLP_DISABLE_AUTO_UPDATE=1` to skip background update checks; add extra clients with `YTDLP_EXTRA_CLIENTS` if a region requires them.
 
 ## Guild Whitelist
 - Music commands are limited to guild IDs in `MUSIC_GUILD_WHITELIST` (defaults include `1403664986089324606` and `858444090374881301`).


### PR DESCRIPTION
## Summary
- skip auto-update entirely when YTDLP_DISABLE_AUTO_UPDATE is set and treat HTTP 403/exit 100 as non-fatal
- adjust default extractor clients based on cookie usage to avoid unsupported-client warnings and Error 153 failures
- document the new env toggles for operators

## Testing
- export YTDLP_COOKIES_JSON='[\n {"name": "SID", "value": "abc"}\n]\n' && python3 scripts/minify_cookies.py
