### PR TITLE
Strip hallucinated quotes from replies

### DIFF
--- a/ai-providers.js
+++ b/ai-providers.js
@@ -81,7 +81,9 @@ function stripJarvisSpeakerPrefix(text) {
 function sanitizeAssistantMessage(text) {
   if (!text || typeof text !== 'string') return text;
   const layered = extractFinalPayload(cleanThinkingOutput(sanitizeModelOutput(text)));
-  return stripWrappingQuotes(stripJarvisSpeakerPrefix(layered));
+  const noOuterQuotes = stripWrappingQuotes(layered);
+  const withoutPrefix = stripJarvisSpeakerPrefix(noOuterQuotes);
+  return stripWrappingQuotes(withoutPrefix);
 }
 /** END: minimal thinking/final scrub helpers (added) **/
 


### PR DESCRIPTION
## Summary
- add sanitizer to remove wrapping quotes and `Jarvis:` prefixes from assistant replies
- route all model outputs through shared sanitizer helper
- render unicode emojis in clip images via Twemoji assets and standardize emoji sizing

## Testing
- npm test
