### PR TITLE
Fix clip emoji spacing regression

### DIFF
--- a/discord-handlers-parts/part-01.js
+++ b/discord-handlers-parts/part-01.js
@@ -1353,6 +1353,8 @@
         const segments = this.splitTextWithEmojisAndMentions(text, customEmojis, mentions);
         const lineHeight = 22;
         const emojiSize = 18;
+        const emojiSpacing = typeof this.clipEmojiSpacing === 'number' ? this.clipEmojiSpacing : 3;
+        const emojiAdvance = emojiSize + emojiSpacing;
 
         let lineCount = 1;
         let currentLineWidth = 0;
@@ -1398,11 +1400,10 @@
                     }
                     currentLineWidth += width;
                 } else {
-                    const width = emojiSize + 3;
-                    if (currentLineWidth + width > maxWidth && currentLineWidth > 0) {
+                    if (currentLineWidth + emojiAdvance > maxWidth && currentLineWidth > 0) {
                         advanceLine();
                     }
-                    currentLineWidth += width;
+                    currentLineWidth += emojiAdvance;
                 }
             } else if (segment.type === 'mention') {
                 const mentionTokens = segment.text.split(/(\n|\s+)/);

--- a/discord-handlers-parts/part-02.js
+++ b/discord-handlers-parts/part-02.js
@@ -169,6 +169,8 @@
         let currentY = startY;
         const lineHeight = 22;
         const emojiSize = 18;
+        const emojiSpacing = typeof this.clipEmojiSpacing === 'number' ? this.clipEmojiSpacing : 3;
+        const emojiAdvance = emojiSize + emojiSpacing;
 
         const segments = this.splitTextWithEmojisAndMentions(text, customEmojis, mentions);
 
@@ -265,12 +267,12 @@
                         const emojiWidth = emojiSize;
                         const emojiHeight = emojiSize;
 
-                        if (currentLineWidth + emojiWidth > maxWidth && currentLineWidth > 0) {
+                        if (currentLineWidth + emojiAdvance > maxWidth && currentLineWidth > 0) {
                             advanceLine();
                         }
 
                         ctx.drawImage(emojiImg, startX + currentLineWidth, currentY, emojiWidth, emojiHeight);
-                        currentLineWidth += emojiWidth + 3;
+                        currentLineWidth += emojiAdvance;
                         console.log('Successfully rendered emoji:', segment.name);
                     } catch (error) {
                         console.warn('Failed to load emoji:', { name: segment.name, url: segment.url, error: error.message });
@@ -283,12 +285,12 @@
                                 const emojiWidth = emojiSize;
                                 const emojiHeight = emojiSize;
 
-                                if (currentLineWidth + emojiWidth > maxWidth && currentLineWidth > 0) {
+                                if (currentLineWidth + emojiAdvance > maxWidth && currentLineWidth > 0) {
                                     advanceLine();
                                 }
 
                                 ctx.drawImage(emojiImg, startX + currentLineWidth, currentY, emojiWidth, emojiHeight);
-                                currentLineWidth += emojiWidth + 3;
+                                currentLineWidth += emojiAdvance;
                                 console.log('Successfully rendered emoji with alternative URL:', segment.name);
                             } else {
                                 throw new Error('Alternative URL same as original');


### PR DESCRIPTION
## Summary
- define shared emoji spacing when measuring clip text height to avoid undefined references
- reuse the same spacing when drawing emoji images so wrapping stays consistent

## Testing
- npm test
