### PR TITLE
Add crypto command and memory opt preferences

### DIFF
--- a/database.js
+++ b/database.js
@@ -286,6 +286,24 @@ class DatabaseManager {
             );
     }
 
+    async clearUserMemories(userId) {
+        if (!this.isConnected) throw new Error('Database not connected');
+
+        try {
+            await this.db
+                .collection(config.database.collections.conversations)
+                .deleteMany({ userId });
+        } catch (error) {
+            console.error('Failed to purge stored conversations for user', userId, error);
+        }
+
+        try {
+            await vaultClient.purgeUserMemories(userId);
+        } catch (error) {
+            console.error('Failed to purge secure memories for user', userId, error);
+        }
+    }
+
     async clearDatabase() {
         if (!this.isConnected) throw new Error("Database not connected");
 

--- a/index.js
+++ b/index.js
@@ -147,6 +147,20 @@ const allCommands = [
         )
         .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()
+        .setName('opt')
+        .setDescription('Manage whether Jarvis retains your memories')
+        .addStringOption(option =>
+            option
+                .setName('mode')
+                .setDescription('Choose whether to opt-in or opt-out of memory storage')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Opt in to memory storage', value: 'in' },
+                    { name: 'Opt out of memory storage', value: 'out' }
+                )
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
         .setName("reset")
         .setDescription("Delete your conversation history and profile with Jarvis")
         .setContexts([InteractionContextType.Guild]),

--- a/src/core/command-registry.js
+++ b/src/core/command-registry.js
@@ -77,6 +77,14 @@ const commandDefinitions = [
         ephemeral: false
     },
     {
+        name: 'opt',
+        description: 'Control whether Jarvis stores your conversation history.',
+        category: 'Utilities',
+        usage: '/opt mode:<in|out>',
+        feature: 'utilities',
+        ephemeral: true
+    },
+    {
         name: 'reset',
         description: 'Clear your conversation history and profile.',
         category: 'Core Systems',


### PR DESCRIPTION
- add /crypto slash command and CoinMarketCap integration
- introduce /opt to manage user memory retention
- support memory opt-out by purging stored conversations and vault entries
- defaults keep memory on; profile/storage respects preference