### PR TITLE
feature/crypto command

### DIFF
--- a/discord-handlers-parts/part-00.js
+++ b/discord-handlers-parts/part-00.js
@@ -35,6 +35,7 @@ const { commandFeatureMap, SLASH_EPHEMERAL_COMMANDS } = require('./src/core/comm
 const { isFeatureGloballyEnabled, isFeatureEnabledForGuild } = require('./src/core/feature-flags');
 const memeCanvas = require('./src/utils/meme-canvas');
 const cryptoClient = require('./crypto-client');
+const vaultClient = require('./vault-client');
 
 function isCommandEnabled(commandName) {
     const featureKey = commandFeatureMap.get(commandName);
@@ -83,6 +84,7 @@ class DiscordHandlers {
         this.autoModRuleName = 'Jarvis Blacklist Filter';
         this.maxAutoModKeywordsPerRule = 1000;
         this.defaultAutoModMessage = 'Jarvis blocked this message for containing prohibited language.';
+        this.missionCooldownMs = 12 * 60 * 60 * 1000;
         this.serverStatsCategoryName = '────────│ Server Stats │────────';
         this.serverStatsChannelLabels = {
             total: 'Member Count',
@@ -112,6 +114,82 @@ class DiscordHandlers {
         this.clipEmojiRenderSize = 22;
         this.clipEmojiSpacing = 4;
         this.clipLineHeight = 24;
+        this.banterLines = [
+            'I filed that under “impressive improvisation,” sir.',
+            'Telemetry suggests a 92% chance you’re up to mischief, ma’am.',
+            'I’ve adjusted the sarcasm filters to match your current vibe, sir.',
+            'I preheated the lab. Thought you might want to make a mess again, ma’am.',
+            'I sharpened your wits while you were offline. You’re welcome, sir.',
+            'Consider this a friendly systems check: delightful chaos detected.'
+        ];
+        this.roastTemplates = [
+            'Deploying shade cannons on {target}. Try not to melt, sir.',
+            '{target}, even my error logs have more direction.',
+            '{target}, if brilliance were a drive, you’re stuck in neutral.',
+            '{target}, I’ve met loading bars with more resolve.',
+            'I ran the numbers, {target}. Comedy requires a punchline—you are optional.'
+        ];
+        this.flatterTemplates = [
+            '{target}, your presence calibrates the whole grid.',
+            '{target}, even Stark’s ego flinches when you walk in.',
+            'I logged your stride, {target}. It ranks among the top five trajectories.',
+            '{target}, the servers purr a little smoother when you’re nearby.',
+            'Consider this official: {target} remains the premium upgrade.'
+        ];
+        this.toastTemplates = [
+            'A toast to {target}: may your glitches be charming and your victories loud.',
+            'Raise a glass for {target}; brilliance executed with reckless elegance.',
+            'To {target}: proof that chaos, when curated, is unstoppable.',
+            'Celebrating {target}—the software patch the universe didn’t deserve.',
+            'Here’s to {target}; long may your legend crash their humble firewalls.'
+        ];
+        this.triviaQuestions = [
+            {
+                question: 'Which Stark suit first featured full nanotech deployment?',
+                choices: ['Mark 42', 'Mark 46', 'Mark 50', 'Mark 85'],
+                answer: 'Mark 50'
+            },
+            {
+                question: 'What element did Tony synthesize to replace palladium?',
+                choices: ['Vibranium', 'Badassium', 'Chromium', 'Proteanium'],
+                answer: 'Badassium'
+            },
+            {
+                question: 'Which protocol locks down the Avengers Tower?',
+                choices: ['Protocol House Party', 'Protocol Barn Door', 'Protocol Sky Shield', 'Protocol Jarvis Prime'],
+                answer: 'Protocol Barn Door'
+            },
+            {
+                question: 'Who reprogrammed Vision’s mind stone interface besides Stark?',
+                choices: ['Banner', 'Shuri', 'Pym', 'Cho'],
+                answer: 'Banner'
+            }
+        ];
+        this.cipherPhrases = [
+            'Arc reactor diagnostics nominal',
+            'Stark Expo security override',
+            'Deploy the Hall of Armor',
+            'Engage satellite uplink now',
+            'Initiate Mark Seven extraction'
+        ];
+        this.scrambleWords = [
+            'repulsor',
+            'vibranium',
+            'arcforge',
+            'nanotech',
+            'ultrasonic',
+            'starkware'
+        ];
+        this.missions = [
+            'Share a photo of your current setup—Jarvis will rate the chaos.',
+            'Teach the channel one obscure fact. Bonus points for science fiction.',
+            'Designate a teammate and compliment their latest win.',
+            'Queue up a nostalgic MCU moment and drop the timestamp.',
+            'Build a playlist with five tracks that motivate your inner Avenger.',
+            'Swap desktop wallpapers for the day and show your new look.',
+            'Document a mini DIY project and share progress before midnight.',
+            'Run a five-minute stretch break and ping the squad to join.'
+        ];
     }
 
     async isCommandFeatureEnabled(commandName, guild = null) {

--- a/index.js
+++ b/index.js
@@ -161,6 +161,50 @@ const allCommands = [
         )
         .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()
+        .setName('mission')
+        .setDescription('Receive a fresh Stark Industries daily directive')
+        .addBooleanOption((option) =>
+            option
+                .setName('refresh')
+                .setDescription('Request a new mission (cooldown enforced)')
+                .setRequired(false)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('memory')
+        .setDescription('Inspect your stored Jarvis memories')
+        .addIntegerOption((option) =>
+            option
+                .setName('entries')
+                .setDescription('Number of entries to review (1-10)')
+                .setRequired(false)
+                .setMinValue(1)
+                .setMaxValue(10)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('persona')
+        .setDescription('Switch Jarvis between alternate personas')
+        .addStringOption((option) =>
+            option
+                .setName('mode')
+                .setDescription('Persona to activate or preview')
+                .setRequired(false)
+                .addChoices(
+                    { name: 'Jarvis (default)', value: 'jarvis' },
+                    { name: 'Tony Stark', value: 'stark' },
+                    { name: 'FRIDAY', value: 'friday' },
+                    { name: 'Ultron', value: 'ultron' }
+                )
+        )
+        .addBooleanOption((option) =>
+            option
+                .setName('preview')
+                .setDescription('Preview tone without saving it')
+                .setRequired(false)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
         .setName('t')
         .setDescription('Search the knowledge base for indexed context')
         .addStringOption(option =>
@@ -330,6 +374,58 @@ const allCommands = [
                 .setDescription('Who deserves the bonk?')
                 .setRequired(true)
         )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('banter')
+        .setDescription('Trade a line of Stark-grade banter')
+        .addUserOption((option) =>
+            option
+                .setName('target')
+                .setDescription('Optional recipient of the banter')
+                .setRequired(false)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('roast')
+        .setDescription('Deploy a refined Stark Industries roast')
+        .addUserOption((option) =>
+            option
+                .setName('target')
+                .setDescription('Who should feel the burn?')
+                .setRequired(true)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('flatter')
+        .setDescription('Deliver premium Jarvis-approved praise')
+        .addUserOption((option) =>
+            option
+                .setName('target')
+                .setDescription('Optional honoree')
+                .setRequired(false)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('toast')
+        .setDescription('Raise a cinematic toast to an ally')
+        .addUserOption((option) =>
+            option
+                .setName('target')
+                .setDescription('Optional honoree')
+                .setRequired(false)
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('trivia')
+        .setDescription('Challenge yourself with Stark trivia')
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('cipher')
+        .setDescription('Crack a rotating Stark cipher')
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('scramble')
+        .setDescription('Unscramble a Stark Industries keyword')
         .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()
         .setName("news")

--- a/src/core/command-registry.js
+++ b/src/core/command-registry.js
@@ -85,6 +85,30 @@ const commandDefinitions = [
         ephemeral: true
     },
     {
+        name: 'mission',
+        description: 'Receive a rotating daily directive from Jarvis.',
+        category: 'Fun',
+        usage: '/mission [refresh:true]',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'memory',
+        description: 'Review the memories Jarvis currently retains for you.',
+        category: 'Personal Tools',
+        usage: '/memory [entries:5]',
+        feature: 'utilities',
+        ephemeral: true
+    },
+    {
+        name: 'persona',
+        description: 'Preview or switch Jarvis into alternate personas.',
+        category: 'Personal Tools',
+        usage: '/persona mode:<persona> [preview:true]',
+        feature: 'utilities',
+        ephemeral: true
+    },
+    {
         name: 't',
         description: 'Search the server knowledge base for stored context.',
         category: 'Utilities',
@@ -217,6 +241,62 @@ const commandDefinitions = [
         description: 'Deliver comedic corrective action.',
         category: 'Fun',
         usage: '/bonk <user>',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'banter',
+        description: 'Trade a Stark-grade banter line.',
+        category: 'Fun',
+        usage: '/banter [user]',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'roast',
+        description: 'Deploy a refined Jarvis roast.',
+        category: 'Fun',
+        usage: '/roast <user>',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'flatter',
+        description: 'Deliver a premium compliment.',
+        category: 'Fun',
+        usage: '/flatter [user]',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'toast',
+        description: 'Raise a celebratory toast.',
+        category: 'Fun',
+        usage: '/toast [user]',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'trivia',
+        description: 'Answer Marvel/Stark trivia prompts.',
+        category: 'Fun',
+        usage: '/trivia',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'cipher',
+        description: 'Decode a rotating Stark cipher.',
+        category: 'Fun',
+        usage: '/cipher',
+        feature: 'funUtilities',
+        ephemeral: false
+    },
+    {
+        name: 'scramble',
+        description: 'Unscramble a Stark Industries keyword.',
+        category: 'Fun',
+        usage: '/scramble',
         feature: 'funUtilities',
         ephemeral: false
     },


### PR DESCRIPTION
- **fix: ensure economy profiles always return defaults**
- **refactor: slash-only commands and remove economy/xp**
- **feat: add /crypto command with CoinMarketCap integration**
- **fix: ensure message handler prompts use slash commands**
- **fix: restore web search fallback flow**
- **fix: clean trailing search logic duplication**
- **fix: keep legacy search flow after slash reminders**
- **feat: add /opt command for memory preferences**
- **fix: re-enable wake words when message content intent active**
- **fix: allow /reset to run in DMs**
- **feat: add /t search command and offline embedding fallback**
- **Add fun slash suite, persona controls, and knowledge fallback**
