### PR TITLE
feature/image effects

### DIFF
--- a/discord-handlers-parts/part-00.js
+++ b/discord-handlers-parts/part-00.js
@@ -34,6 +34,7 @@ const { recordCommandRun } = require('./src/utils/telemetry');
 const { commandFeatureMap, SLASH_EPHEMERAL_COMMANDS } = require('./src/core/command-registry');
 const { isFeatureGloballyEnabled, isFeatureEnabledForGuild } = require('./src/core/feature-flags');
 const memeCanvas = require('./src/utils/meme-canvas');
+const imageEffects = require('./src/utils/image-effects');
 const cryptoClient = require('./crypto-client');
 const vaultClient = require('./vault-client');
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const { gatherHealthSnapshot } = require('./diagnostics');
 const { commandList: musicCommandList } = require("./src/commands/music");
 const { commandFeatureMap } = require('./src/core/command-registry');
 const { isFeatureGloballyEnabled } = require('./src/core/feature-flags');
+const imageEffects = require('./src/utils/image-effects');
 
 initializeDatabaseClients()
     .then(() => console.log('MongoDB clients initialized for main and vault databases.'))
@@ -35,6 +36,8 @@ const client = new Client({
 });
 
 // ------------------------ Slash Command Registration ------------------------
+const imageFilterChoices = imageEffects.listEffects();
+
 const allCommands = [
     new SlashCommandBuilder()
         .setName("jarvis")
@@ -503,6 +506,36 @@ const allCommands = [
                         .setRequired(false)
                         .setMaxLength(120)
                 )
+        )
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
+    new SlashCommandBuilder()
+        .setName('filter')
+        .setDescription('Apply cinematic filters to an image')
+        .addAttachmentOption((option) =>
+            option
+                .setName('image')
+                .setDescription('Image to transform')
+                .setRequired(true)
+        )
+        .addStringOption((option) => {
+            let builder = option
+                .setName('style')
+                .setDescription('Filter preset to apply')
+                .setRequired(true);
+
+            imageFilterChoices.forEach(({ key, label }) => {
+                builder = builder.addChoices({ name: label, value: key });
+            });
+
+            return builder;
+        })
+        .addIntegerOption((option) =>
+            option
+                .setName('intensity')
+                .setDescription('Optional intensity for pixelate, blur, and deep fry')
+                .setRequired(false)
+                .setMinValue(1)
+                .setMaxValue(50)
         )
         .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()

--- a/src/core/command-registry.js
+++ b/src/core/command-registry.js
@@ -221,6 +221,14 @@ const commandDefinitions = [
         ephemeral: false
     },
     {
+        name: 'filter',
+        description: 'Apply Jarvis cinematic filters to an image.',
+        category: 'Meme Lab',
+        usage: '/filter style:<preset> image:<attachment>',
+        feature: 'memeTools',
+        ephemeral: false
+    },
+    {
         name: 'eightball',
         description: 'Ask the oracle of Stark for guidance.',
         category: 'Fun',

--- a/src/utils/image-effects.js
+++ b/src/utils/image-effects.js
@@ -1,0 +1,138 @@
+const sharp = require('sharp');
+
+const clamp = (value, min, max) => {
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+        return min;
+    }
+    return Math.min(Math.max(num, min), max);
+};
+
+const ensurePng = (pipeline) => pipeline.png({ progressive: false }).toBuffer();
+
+async function applyInvert(buffer) {
+    return ensurePng(sharp(buffer).ensureAlpha().negate({ alpha: false }));
+}
+
+async function applyGrayscale(buffer) {
+    return ensurePng(sharp(buffer).ensureAlpha().grayscale());
+}
+
+async function applySepia(buffer) {
+    const sepiaMatrix = [
+        [0.393, 0.769, 0.189],
+        [0.349, 0.686, 0.168],
+        [0.272, 0.534, 0.131]
+    ];
+    return ensurePng(sharp(buffer).ensureAlpha().recomb(sepiaMatrix));
+}
+
+async function applyPixelate(buffer, options = {}) {
+    const blockSize = clamp(options.intensity ?? 18, 4, 80);
+    const metadata = await sharp(buffer).metadata();
+    const width = metadata.width || 512;
+    const height = metadata.height || 512;
+    const downscaleWidth = Math.max(1, Math.round(width / blockSize));
+    const downscaleHeight = Math.max(1, Math.round(height / blockSize));
+
+    return ensurePng(
+        sharp(buffer)
+            .ensureAlpha()
+            .resize(downscaleWidth, downscaleHeight, { fit: 'fill' })
+            .resize(width, height, { fit: 'fill', kernel: sharp.kernel.nearest })
+    );
+}
+
+async function applyBlur(buffer, options = {}) {
+    const radius = clamp(options.intensity ?? 4, 0.3, 25);
+    return ensurePng(sharp(buffer).ensureAlpha().blur(radius));
+}
+
+async function applyDeepfry(buffer, options = {}) {
+    const passes = clamp(options.intensity ?? 2, 1, 5);
+    let working = buffer;
+
+    for (let index = 0; index < passes; index += 1) {
+        const quality = Math.max(5, 60 - index * 10);
+        working = await sharp(working)
+            .modulate({
+                saturation: 1.5 + index * 0.1,
+                brightness: 1.05
+            })
+            .linear(1.1 + index * 0.1, -15)
+            .jpeg({ quality })
+            .toBuffer();
+    }
+
+    return ensurePng(
+        sharp(working)
+            .sharpen(passes * 2, 1.5, 0.8)
+            .modulate({ saturation: 1.6, brightness: 1.05 })
+    );
+}
+
+const EFFECT_DEFINITIONS = {
+    invert: {
+        label: 'Invert Colors',
+        description: 'Flip the palette into its negative.',
+        supportsIntensity: false,
+        handler: applyInvert
+    },
+    grayscale: {
+        label: 'Noir Grayscale',
+        description: 'Drain the color for a cinematic noir look.',
+        supportsIntensity: false,
+        handler: applyGrayscale
+    },
+    sepia: {
+        label: 'Sepia Film',
+        description: 'Apply warm film tones inspired by vintage reels.',
+        supportsIntensity: false,
+        handler: applySepia
+    },
+    pixelate: {
+        label: 'Pixelate',
+        description: 'Crunch the image into chunky pixels.',
+        supportsIntensity: true,
+        handler: applyPixelate
+    },
+    blur: {
+        label: 'Soft Blur',
+        description: 'Diffuse the frame into a dreamy blur.',
+        supportsIntensity: true,
+        handler: applyBlur
+    },
+    deepfry: {
+        label: 'Deep Fry',
+        description: 'Over-saturate, oversharpen, and compress for meme chaos.',
+        supportsIntensity: true,
+        handler: applyDeepfry
+    }
+};
+
+async function applyEffect(effectName, buffer, options = {}) {
+    const definition = EFFECT_DEFINITIONS[effectName];
+    if (!definition) {
+        throw new Error(`Unknown filter effect: ${effectName}`);
+    }
+    return definition.handler(buffer, options);
+}
+
+function listEffects() {
+    return Object.entries(EFFECT_DEFINITIONS).map(([key, definition]) => ({
+        key,
+        label: definition.label,
+        description: definition.description,
+        supportsIntensity: Boolean(definition.supportsIntensity)
+    }));
+}
+
+function getEffectDefinition(effectName) {
+    return EFFECT_DEFINITIONS[effectName] || null;
+}
+
+module.exports = {
+    applyEffect,
+    listEffects,
+    getEffectDefinition
+};


### PR DESCRIPTION
- **fix: ensure economy profiles always return defaults**
- **refactor: slash-only commands and remove economy/xp**
- **feat: add /crypto command with CoinMarketCap integration**
- **fix: ensure message handler prompts use slash commands**
- **fix: restore web search fallback flow**
- **fix: clean trailing search logic duplication**
- **fix: keep legacy search flow after slash reminders**
- **feat: add /opt command for memory preferences**
- **fix: re-enable wake words when message content intent active**
- **fix: allow /reset to run in DMs**
- **feat: add /t search command and offline embedding fallback**
- **Add fun slash suite, persona controls, and knowledge fallback**
- **Relax member log TTL partial filter for Mongo compatibility**
- **Add /kb list helper and ease embedding search threshold**
- **Add cinematic image filter slash command**
