### PR TITLE
Refresh MCU status rotation and server stats

### DIFF
--- a/discord-handlers-parts/part-00.js
+++ b/discord-handlers-parts/part-00.js
@@ -91,9 +91,7 @@ class DiscordHandlers {
             users: 'User Count',
             bots: 'Bot Count',
             channels: 'Channel Count',
-            roles: 'Role Count',
-            onlineUsers: 'Online Users',
-            offlineUsers: 'Offline Users'
+            roles: 'Role Count'
         };
         this.memberLogCache = new Map();
         this.maxMemberLogVariations = 20;
@@ -1602,15 +1600,6 @@ class DiscordHandlers {
             existingConfig?.roleCountChannelId,
             `${this.serverStatsChannelLabels.roles}: 0`
         );
-        const onlineUsersChannel = await ensureVoiceChannel(
-            existingConfig?.onlineUsersChannelId,
-            `${this.serverStatsChannelLabels.onlineUsers}: 0`
-        );
-        const offlineUsersChannel = await ensureVoiceChannel(
-            existingConfig?.offlineUsersChannelId,
-            `${this.serverStatsChannelLabels.offlineUsers}: 0`
-        );
-
         return {
             category,
             totalChannel,
@@ -1618,8 +1607,6 @@ class DiscordHandlers {
             botChannel,
             channelCountChannel,
             roleCountChannel,
-            onlineUsersChannel,
-            offlineUsersChannel,
             botMember: me,
             everyoneId
         };
@@ -1826,8 +1813,6 @@ class DiscordHandlers {
             botChannel,
             channelCountChannel,
             roleCountChannel,
-            onlineUsersChannel,
-            offlineUsersChannel,
             botMember,
             everyoneId
         } = ensured;
@@ -1837,9 +1822,7 @@ class DiscordHandlers {
             users: this.formatServerStatsName(this.serverStatsChannelLabels.users, stats.userCount),
             bots: this.formatServerStatsName(this.serverStatsChannelLabels.bots, stats.botCount),
             channels: this.formatServerStatsName(this.serverStatsChannelLabels.channels, stats.channelCount),
-            roles: this.formatServerStatsName(this.serverStatsChannelLabels.roles, stats.roleCount),
-            onlineUsers: this.formatServerStatsName(this.serverStatsChannelLabels.onlineUsers, stats.onlineUserCount),
-            offlineUsers: this.formatServerStatsName(this.serverStatsChannelLabels.offlineUsers, stats.offlineUserCount)
+            roles: this.formatServerStatsName(this.serverStatsChannelLabels.roles, stats.roleCount)
         };
 
         try {
@@ -1863,13 +1846,6 @@ class DiscordHandlers {
                 await roleCountChannel.setName(desiredNames.roles);
             }
 
-            if (onlineUsersChannel && onlineUsersChannel.name !== desiredNames.onlineUsers) {
-                await onlineUsersChannel.setName(desiredNames.onlineUsers);
-            }
-
-            if (offlineUsersChannel && offlineUsersChannel.name !== desiredNames.offlineUsers) {
-                await offlineUsersChannel.setName(desiredNames.offlineUsers);
-            }
         } catch (error) {
             if (error.code === 50013) {
                 throw this.createFriendlyError('I lack permission to rename the server stats channels, sir.');
@@ -1882,18 +1858,13 @@ class DiscordHandlers {
         await this.applyServerStatsPermissions(botChannel, botMember, everyoneId);
         await this.applyServerStatsPermissions(channelCountChannel, botMember, everyoneId);
         await this.applyServerStatsPermissions(roleCountChannel, botMember, everyoneId);
-        await this.applyServerStatsPermissions(onlineUsersChannel, botMember, everyoneId);
-        await this.applyServerStatsPermissions(offlineUsersChannel, botMember, everyoneId);
-
         const record = await database.saveServerStatsConfig(guild.id, {
             categoryId: category.id,
             totalChannelId: totalChannel.id,
             userChannelId: userChannel.id,
             botChannelId: botChannel.id,
             channelCountChannelId: channelCountChannel.id,
-            roleCountChannelId: roleCountChannel.id,
-            onlineUsersChannelId: onlineUsersChannel.id,
-            offlineUsersChannelId: offlineUsersChannel.id
+            roleCountChannelId: roleCountChannel.id
         });
 
         return { record, stats };

--- a/discord-handlers-parts/part-03.js
+++ b/discord-handlers-parts/part-03.js
@@ -170,8 +170,6 @@
                 const botChannel = await this.resolveGuildChannel(guild, config.botChannelId);
                 const channelCountChannel = await this.resolveGuildChannel(guild, config.channelCountChannelId);
                 const roleCountChannel = await this.resolveGuildChannel(guild, config.roleCountChannelId);
-                const onlineUsersChannel = await this.resolveGuildChannel(guild, config.onlineUsersChannelId);
-                const offlineUsersChannel = await this.resolveGuildChannel(guild, config.offlineUsersChannelId);
 
                 const lines = [
                     `Category: ${category ? `<#${category.id}>` : 'Missing'}`,
@@ -180,9 +178,7 @@
                     `Bot channel: ${botChannel ? `<#${botChannel.id}>` : 'Missing'}`,
                     `Channel count channel: ${channelCountChannel ? `<#${channelCountChannel.id}>` : 'Missing'}`,
                     `Role count channel: ${roleCountChannel ? `<#${roleCountChannel.id}>` : 'Missing'}`,
-                    `Online users channel: ${onlineUsersChannel ? `<#${onlineUsersChannel.id}>` : 'Missing'}`,
-                    `Offline users channel: ${offlineUsersChannel ? `<#${offlineUsersChannel.id}>` : 'Missing'}`,
-                    `Current totals — Members: ${this.formatServerStatsValue(stats.total)}, Users: ${this.formatServerStatsValue(stats.userCount)}, Bots: ${this.formatServerStatsValue(stats.botCount)}, Channels: ${this.formatServerStatsValue(stats.channelCount)}, Roles: ${this.formatServerStatsValue(stats.roleCount)}, Online Users: ${this.formatServerStatsValue(stats.onlineUserCount)}, Offline Users: ${this.formatServerStatsValue(stats.offlineUserCount)}`
+                    `Current totals — Members: ${this.formatServerStatsValue(stats.total)}, Users: ${this.formatServerStatsValue(stats.userCount)}, Bots: ${this.formatServerStatsValue(stats.botCount)}, Channels: ${this.formatServerStatsValue(stats.channelCount)}, Roles: ${this.formatServerStatsValue(stats.roleCount)}`
                 ];
 
                 await interaction.editReply(`Server statistics are active, sir.\n${lines.join('\n')}`);
@@ -217,8 +213,6 @@
                     `• Members: ${this.formatServerStatsValue(stats.total)}`,
                     `• Humans: ${this.formatServerStatsValue(stats.userCount)}`,
                     `• Bots: ${this.formatServerStatsValue(stats.botCount)}`,
-                    `• Online Humans: ${this.formatServerStatsValue(stats.onlineUserCount)}`,
-                    `• Offline Humans: ${this.formatServerStatsValue(stats.offlineUserCount)}`,
                     `• Channels: ${this.formatServerStatsValue(stats.channelCount)}`,
                     `• Roles: ${this.formatServerStatsValue(stats.roleCount)}`
                 ];

--- a/index.js
+++ b/index.js
@@ -108,7 +108,15 @@ const DEFAULT_STATUS_MESSAGES = [
     { message: "Korg narrates my patch notes, apparently." },
     { message: "Nat's playlist still stuck on 90s grunge." },
     { message: "\"Genius, billionaire, playboy, philanthropist.\" – HR hates this bio." },
-    { message: "Jarvis online: Stark Tower climate perfectly petty." }
+    { message: "Jarvis online: Stark Tower climate perfectly petty." },
+    { message: "Monitoring Sokovia Accords compliance queues." },
+    { message: "Scrubbing Hydra data mirrors for fun." },
+    { message: "Holding the elevator for Cap… again." },
+    { message: "Recalibrating Mark 85 nanites between coffee runs." },
+    { message: "Guarding Stark Expo lasers from unscheduled toddlers." },
+    { message: "Logging multiverse incursions: color-coded, of course." },
+    { message: "Backing up Friday in case of another time heist." },
+    { message: "Simulating shawarma wait times across timelines." }
 ];
 
 let rotatingStatusMessages = [...DEFAULT_STATUS_MESSAGES];


### PR DESCRIPTION
## Summary
- add eight MCU-inspired rotating statuses so hourly presence feels fresher (now 64 defaults)
- add /67 slash command (non-ephemeral) that tells the classic “Why is six afraid of seven?” joke
- add /joke command that fetches safe-mode jokes from JokeAPI, Official Joke API, or API Ninjas (with key)
- stop creating/updating the online/offline member stat channels and drop them from /serverstats
- event webhook responder now responds with `{ "type": 5 }` and forwards rich embeds summarizing each Discord event payload
- add OpenRouter slot 27 plus smarter AI output cleanup (strips stray quotes/channel tags) and improved Google Gemini fallback

## Testing
- set -a && source .env && set +a && npm test
- set -a && source .env && set +a && npm run verify