### PR TITLE
Fix: Ensure system and user prompts are strings for Groq/OpenRouter providers

### DIFF
--- a/src/core/FreeAIProvider.js
+++ b/src/core/FreeAIProvider.js
@@ -214,6 +214,10 @@ class FreeAIProvider {
             );
         }
 
+        // Ensure prompts are strings (required by some providers like Groq)
+        systemPrompt = systemPrompt != null ? String(systemPrompt) : '';
+        userPrompt = userPrompt != null ? String(userPrompt) : '';
+
         this.metrics.calls++;
         const startTime = Date.now();
 

--- a/src/services/ai-providers.js
+++ b/src/services/ai-providers.js
@@ -626,6 +626,10 @@ class AIProviderManager {
   }
 
   async generateResponse(systemPrompt, userPrompt, maxTokens = (config.ai?.maxTokens || 1024)) {
+    // Ensure prompts are strings (required by some providers like Groq)
+    systemPrompt = systemPrompt != null ? String(systemPrompt) : '';
+    userPrompt = userPrompt != null ? String(userPrompt) : '';
+    
     // Safety check: reinitialize providers if somehow empty (handles rare edge cases)
     if (this.providers.length === 0) {
       console.warn('Provider list was empty - reinitializing providers...');


### PR DESCRIPTION
## Problem
Some Groq, OpenRouter, and other OpenAI-compatible providers were failing with 400 errors:
\\\
'messages.0' : for 'role:system' the following must be satisfied[('messages.0.content' : value must be a string) OR ('messages.0.content.0.type' : property 'type' is missing)])
\\\

## Solution
- Added string conversion at the beginning of \generateResponse\ functions
- Ensures \systemPrompt\ and \userPrompt\ are always strings before being sent to API
- Handles null/undefined values gracefully by converting to empty strings

## Changes
- \src/services/ai-providers.js\ - Added string conversion in AIProviderManager
- \src/core/FreeAIProvider.js\ - Added string conversion in FreeAIProvider

## Testing
This fix ensures all providers receive properly formatted string content, preventing validation errors from strict providers like Groq.