### PR TITLE
Make all Stark economy commands available in DMs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2159,7 +2159,7 @@ const allCommands = [
         .addIntegerOption((option) =>
             option.setName('amount').setDescription('Amount to give').setRequired(true).setMinValue(1)
         )
-        .setContexts([InteractionContextType.Guild]),
+        .setContexts([InteractionContextType.Guild, InteractionContextType.BotDM, InteractionContextType.PrivateChannel]),
     new SlashCommandBuilder()
         .setName('crime')
         .setDescription('Commit a crime for money (risky!)')


### PR DESCRIPTION
Updated /give command to be available in both guilds and DMs. All other Stark economy commands already had full context access.