### PR TITLE
fix: Improve rap battle system with chat blocking and longer battles

### DIFF
--- a/src/services/discord-handlers-parts/part-00.js
+++ b/src/services/discord-handlers-parts/part-00.js
@@ -145,6 +145,7 @@ class DiscordHandlers {
         ];
         // Rap battle state manager
         this.rapBattles = new Map(); // userId -> { channelId, startTime, timeoutId, collector, lastBotMessage }
+        this.rapBattleBlockedUsers = new Map(); // userId -> unblockTimestamp (users blocked from chat after battle ends)
         this.rapBattleComebacksPath = path.join(__dirname, '../../rapping_comebacks');
         this.emojiAssetCache = new Map();
         this.clipEmojiRenderSize = 22;

--- a/src/services/discord-handlers-parts/part-02.js
+++ b/src/services/discord-handlers-parts/part-02.js
@@ -654,6 +654,12 @@
         }
 
         const userId = message.author.id;
+        
+        // Block chat if user is in rap battle or recently ended one (3 second cooldown)
+        if (this.rapBattles.has(userId) || this.isRapBattleBlocked(userId)) {
+            return; // Silently ignore messages during rap battle
+        }
+        
         const messageScope = 'message:jarvis';
         const allowWakeWords = Boolean(config.discord?.messageContent?.enabled);
         const rawContent = typeof message.content === 'string' ? message.content : '';


### PR DESCRIPTION
Improves the rap battle system with better chat blocking and longer battle duration.

## Changes
- Add chat blocking during rap battles to prevent AI responses
- Add 3 second delay after battle ends before unblocking chat
- Change win/lose chance from 75/25 to 50/50
- Only check for win/lose in last 15 seconds to make battles last longer
- Battles now run for most of the 1 minute duration before ending

## Fixes
- Prevents AI from responding during rap battles
- Prevents immediate chat re-enable after battle ends
- Makes battles more balanced and longer